### PR TITLE
修改命令行显示的长度

### DIFF
--- a/src/main/java/tech/lin2j/idea/plugin/ui/UploadUi.java
+++ b/src/main/java/tech/lin2j/idea/plugin/ui/UploadUi.java
@@ -149,7 +149,7 @@ public class UploadUi extends DialogWrapper implements ApplicationListener<Uploa
                 cmd = NoneCommand.INSTANCE;
                 profile.setCommandId(null);
             }
-            commandLabel.setText(cmd.toString());
+            commandLabel.setText(cmd.toString().substring(0, 100) + "...");
         } else {
             commandLabel.setText("");
         }


### PR DESCRIPTION
修改命令行显示的长度，避免命令行过长导致下方取消和上传按钮不显示